### PR TITLE
add config options Internet and ExternalIPAddress

### DIFF
--- a/server/internal/cmd/root.go
+++ b/server/internal/cmd/root.go
@@ -75,8 +75,13 @@ func runRoot(fs *pflag.FlagSet) (err error, exitCode int) {
 	if usedFile != "" {
 		logger.PrintFile("config", usedFile)
 	}
-	internal.Connectivity = common.DNSConnectivity()
-	models.CacheNetworkInterfaces()
+	if !cfg.Internet {
+		internal.Connectivity = false
+		logger.Println("Internet usage is disabled via config.")
+	} else {
+		internal.Connectivity = common.DNSConnectivity()
+		models.CacheNetworkInterfaces(cfg.ExternalIPAddress)
+	}
 	if !internal.Connectivity {
 		logger.Println("No internet connectivity, some features will fallback gracefully.")
 	}
@@ -328,6 +333,8 @@ func initConfig(fs *pflag.FlagSet) (*internal.Configuration, string) {
 		"Log":                         false,
 		"GeneratePlatformUserId":      false,
 		"Authentication":              "disabled",
+		"Internet":                    true,
+		"ExternalIPAddress":           "",
 		"Announcement.Enabled":        true,
 		"Announcement.Multicast":      true,
 		"Announcement.MulticastGroup": common.AnnounceMulticastGroup,
@@ -341,6 +348,8 @@ func initConfig(fs *pflag.FlagSet) (*internal.Configuration, string) {
 		"log":                    "Log",
 		"generatePlatformUserId": "GeneratePlatformUserId",
 		"authentication":         "Authentication",
+		"internet":               "Internet",
+		"externalIPAddress":      "ExternalIPAddress",
 		"announce":               "Announcement.Enabled",
 		"announceMulticast":      "Announcement.Multicast",
 		"announceMulticastGroup": "Announcement.MulticastGroup",

--- a/server/internal/config.go
+++ b/server/internal/config.go
@@ -33,6 +33,8 @@ type Configuration struct {
 	Log                    bool
 	GeneratePlatformUserId bool
 	Authentication         string
+	Internet               bool
+	ExternalIPAddress      string
 	Announcement           Announcement
 	Games                  Games
 }

--- a/server/internal/models/battleServer.go
+++ b/server/internal/models/battleServer.go
@@ -34,8 +34,12 @@ func localIp(r *http.Request) (ip string) {
 var localSubnets []*net.IPNet
 var publicIp string
 
-func CacheNetworkInterfaces() {
-	if internal.Connectivity {
+func CacheNetworkInterfaces(externalIPAddress string) {
+	if externalIPAddress != "" {
+		if ip := net.ParseIP(externalIPAddress); ip != nil && ip.To4() != nil {
+			publicIp = externalIPAddress
+		}
+	} else if internal.Connectivity {
 		if resp, err := http.Get("https://api.ipify.org/"); err == nil {
 			defer func(Body io.ReadCloser) {
 				_ = Body.Close()
@@ -47,6 +51,8 @@ func CacheNetworkInterfaces() {
 				}
 			}
 		}
+	}
+	if internal.Connectivity || externalIPAddress != "" {
 		if publicIp != "" {
 			if ifs, err := common.RunningNetworkInterfaces(); err == nil {
 				for _, ipNets := range ifs {

--- a/server/resources/config/config.toml
+++ b/server/resources/config/config.toml
@@ -6,6 +6,15 @@ Log = false
 # Incompatible with Authentication not set to 'disabled'.
 GeneratePlatformUserId = false
 
+# Manually specify the external/public IPv4 address of this server. If set, this value is used
+# instead of querying https://api.ipify.org/. Useful when Internet = false or when auto-detection
+# is unreliable/undesired. Leave empty to auto-detect (requires Internet = true).
+ExternalIPAddress = ''
+
+# Whether to allow the server to use the Internet at all (DNS connectivity check,
+# authentication, and public IP detection). Set to false for fully offline/air-gapped use.
+Internet = true
+
 # Authentication method to use. Accepted values:
 # required: authenticate the user with the official servers as it was, effectively, the same.
 # cached: authenticate with the official server at least once every 30 days (tied to user platform user id).


### PR DESCRIPTION
This feature adds some config options that lets the server operate entirely off the Internet. I tested successfully with the Internet connected, and disconnected.

These options let the application not depend on the Internet at all, which facilitates the outdated goal of "No data is sent to the Internet."